### PR TITLE
Add test-mif1.heic for HEIC test case

### DIFF
--- a/tests/ImageTypeDetectorTest.php
+++ b/tests/ImageTypeDetectorTest.php
@@ -65,6 +65,7 @@ class ImageTypeDetectorTest extends TestCase
             [__DIR__ . '/images/test.swf', ImageType::SWF],
             [__DIR__ . '/images/test-alpha.heic', ImageType::HEIC],
             [__DIR__ . '/images/test-animation.heic', ImageType::HEIC],
+            [__DIR__ . '/images/test-mif1.heic', ImageType::HEIC],
         ];
     }
 


### PR DESCRIPTION
# Changed log
- It looks like the `test-mif1.heic` is added in this project, but it doesn't include in `ImageTypeDetectorTest` class.
- This PR is for adding this image and it can do this `HEIC` image detection.