### PR TITLE
Drop PHP 7.1, require PHP 7.2+ and upgrade PHPUnit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 dist: xenial
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Image type detection library for PHP.
 
 ## Requirements
 
-* PHP 7.1+
+* PHP 7.2+
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
     "homepage": "https://github.com/selective-php/image-type",
     "license": "MIT",
     "require": {
-        "php": "^7.1"
+        "php": "^7.2"
     },
     "require-dev": {
         "overtrue/phplint": "^1.1",
-        "phpunit/phpunit": "^7",
+        "phpunit/phpunit": "^8",
         "phpstan/phpstan-shim": "^0.11",
         "squizlabs/php_codesniffer": "^3.4"
     },


### PR DESCRIPTION
# Changed log

- Let this package require `php-7.2` version at least.
- Upgrading PHPUnit version for requiring minimum `php-7.2` version.
- Drop `php-7.1` version and add `php-7.4` version during Travis CI build.